### PR TITLE
Added SoldierTemplate Configuration

### DIFF
--- a/WOTC_MoreResistanceLeader/Config/XComMRL.ini
+++ b/WOTC_MoreResistanceLeader/Config/XComMRL.ini
@@ -6,5 +6,6 @@
 	; eComInt_Gifted,
 	; eComInt_Genius,
 	; eComInt_Savant,
+; Note, if SoldierTemplate is not defined or invalid, the template will default to Soldier
 
-+RescueClasses = (ClassName = "WOTC_APA_DirectorKelly", Limit = 2, MinComInt = eComInt_Genius)
++RescueClasses = (SoldierTemplate = "Soldier", ClassName = "WOTC_APA_DirectorKelly", Limit = 2, MinComInt = eComInt_Genius)

--- a/WOTC_MoreResistanceLeader/Src/WOTC_MoreResistanceLeader/Classes/X2DownloadableContentInfo_WOTC_MoreResistanceLeader.uc
+++ b/WOTC_MoreResistanceLeader/Src/WOTC_MoreResistanceLeader/Classes/X2DownloadableContentInfo_WOTC_MoreResistanceLeader.uc
@@ -9,7 +9,6 @@ struct RescueClassData
 
 	structdefaultproperties
 	{
-		SoldierTemplate = 'Soldier';
 		MinComInt = eComInt_Standard;
 	}
 };
@@ -62,14 +61,10 @@ static function name DetermineSoldierTemplate()
 	XComHQ = `XCOMHQ;
 	foreach default.RescueClasses(RescueClass)
 	{
-		// Validate the soldier class, just in case the mod that introduces the class is not enabled
-        Unit = XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(UnitRef.ObjectID));
-		if (Unit.FindSoldierClassTemplate(RescueClass.SoldierTemplate) == none) continue;
-
-
 		iCount = 0; // Init
         foreach XComHQ.Crew(UnitRef)
         {
+        	Unit = XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(UnitRef.ObjectID));
             if (Unit != none && Unit.IsSoldier() && Unit.GetSoldierClassTemplate().DataName == RescueClass.ClassName)
             {
                 iCount++;

--- a/WOTC_MoreResistanceLeader/Src/WOTC_MoreResistanceLeader/Classes/X2DownloadableContentInfo_WOTC_MoreResistanceLeader.uc
+++ b/WOTC_MoreResistanceLeader/Src/WOTC_MoreResistanceLeader/Classes/X2DownloadableContentInfo_WOTC_MoreResistanceLeader.uc
@@ -1,4 +1,4 @@
-class X2DownloadableContentInfo_WOTC_RescueTorqueMod extends X2DownloadableContentInfo;
+class X2DownloadableContentInfo_WOTC_MoreResistanceLeader extends X2DownloadableContentInfo;
 
 struct RescueClassData
 {

--- a/WOTC_MoreResistanceLeader/Src/WOTC_MoreResistanceLeader/Classes/X2DownloadableContentInfo_WOTC_MoreResistanceLeader.uc
+++ b/WOTC_MoreResistanceLeader/Src/WOTC_MoreResistanceLeader/Classes/X2DownloadableContentInfo_WOTC_MoreResistanceLeader.uc
@@ -1,13 +1,15 @@
-class X2DownloadableContentInfo_WOTC_MoreResistanceLeader extends X2DownloadableContentInfo;
+class X2DownloadableContentInfo_WOTC_RescueTorqueMod extends X2DownloadableContentInfo;
 
 struct RescueClassData
 {
+	var name SoldierTemplate;
 	var name ClassName;
 	var int Limit;
 	var ECombatIntelligence MinComInt;
 
 	structdefaultproperties
 	{
+		SoldierTemplate = 'Soldier';
 		MinComInt = eComInt_Standard;
 	}
 };
@@ -33,7 +35,7 @@ static function name DetermineSoldierClass()
 		iCount = 0; // Init
         foreach XComHQ.Crew(UnitRef)
         {
-            Unit = XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(UnitRef.ObjectID));
+        	Unit = XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(UnitRef.ObjectID));
             if (Unit != none && Unit.IsSoldier() && Unit.GetSoldierClassTemplate().DataName == RescueClass.ClassName)
             {
                 iCount++;
@@ -47,6 +49,40 @@ static function name DetermineSoldierClass()
 	}
 
 	return '';
+}
+
+static function name DetermineSoldierTemplate()
+{
+	local RescueClassData RescueClass;
+	local XComGameState_Unit Unit;
+	local StateObjectReference UnitRef;
+	local XComGameState_HeadquartersXCom XComHQ;
+	local int iCount;
+
+	XComHQ = `XCOMHQ;
+	foreach default.RescueClasses(RescueClass)
+	{
+		// Validate the soldier class, just in case the mod that introduces the class is not enabled
+        Unit = XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(UnitRef.ObjectID));
+		if (Unit.FindSoldierClassTemplate(RescueClass.SoldierTemplate) == none) continue;
+
+
+		iCount = 0; // Init
+        foreach XComHQ.Crew(UnitRef)
+        {
+            if (Unit != none && Unit.IsSoldier() && Unit.GetSoldierClassTemplate().DataName == RescueClass.ClassName)
+            {
+                iCount++;
+            }
+        }
+
+        if (iCount < RescueClass.Limit)
+        {
+            return RescueClass.SoldierTemplate;
+        }
+	}
+
+	return 'Soldier';
 }
 
 static function ECombatIntelligence GetMinComInt(name SoldierClassName)

--- a/WOTC_MoreResistanceLeader/Src/WOTC_MoreResistanceLeader/Classes/X2StrategyElement_MRLRewards.uc
+++ b/WOTC_MoreResistanceLeader/Src/WOTC_MoreResistanceLeader/Classes/X2StrategyElement_MRLRewards.uc
@@ -12,9 +12,15 @@ static function array<X2DataTemplate> CreateTemplates()
 static function X2DataTemplate CreateMRLRewardTemplate()
 {
 	local X2RewardTemplate Template;
+	local name NewTemplateName;
 
 	`CREATE_X2Reward_TEMPLATE(Template, 'Reward_ResistanceLeader');
-	Template.rewardObjectTemplateName = 'Soldier';
+	NewTemplateName = class'X2DownloadableContentInfo_WOTC_MoreResistanceLeader'.static.DetermineSoldierTemplate();
+	if (NewTemplateName == '')
+	{
+		NewTemplateName = 'Soldier';
+	}
+	Template.rewardObjectTemplateName = NewTemplateName;
 
 	Template.GenerateRewardFn = GenerateMRLPersonnelReward;
 	Template.SetRewardFn = SetPersonnelReward;
@@ -53,20 +59,13 @@ static function XComGameState_Unit CreateMRLUnit(XComGameState NewGameState, nam
 	local XComGameState_Unit NewUnitState;
 	local XComGameState_HeadquartersXCom XComHQ;
 	local XComGameState_HeadquartersResistance ResistanceHQ;
-	local name ClassName, NewTemplateName;
+	local name ClassName;
 	local int idx, NewRank, StartingIdx;
 
 	History = `XCOMHISTORY;
 
-	// Optain the template from the config. If not defined or invalid, just une the default template.
-	NewTemplateName = class'X2DownloadableContentInfo_WOTC_MoreResistanceLeader'.static.DetermineSoldierTemplate();
-	if (ClassName == '')
-	{
-		NewTemplateName = 'Soldier';
-	}
-
 	//Use the character pool's creation method to retrieve a unit
-	NewUnitState = `CHARACTERPOOLMGR.CreateCharacter(NewGameState, `XPROFILESETTINGS.Data.m_eCharPoolUsage, NewTemplateName, nmCountry);
+	NewUnitState = `CHARACTERPOOLMGR.CreateCharacter(NewGameState, `XPROFILESETTINGS.Data.m_eCharPoolUsage, nmCharacter, nmCountry);
 	NewUnitState.RandomizeStats();	
 
 	if (NewUnitState.IsSoldier())

--- a/WOTC_MoreResistanceLeader/Src/WOTC_MoreResistanceLeader/Classes/X2StrategyElement_MRLRewards.uc
+++ b/WOTC_MoreResistanceLeader/Src/WOTC_MoreResistanceLeader/Classes/X2StrategyElement_MRLRewards.uc
@@ -53,13 +53,20 @@ static function XComGameState_Unit CreateMRLUnit(XComGameState NewGameState, nam
 	local XComGameState_Unit NewUnitState;
 	local XComGameState_HeadquartersXCom XComHQ;
 	local XComGameState_HeadquartersResistance ResistanceHQ;
-	local name ClassName;
+	local name ClassName, NewTemplateName;
 	local int idx, NewRank, StartingIdx;
 
 	History = `XCOMHISTORY;
 
+	// Optain the template from the config. If not defined or invalid, just une the default template.
+	NewTemplateName = class'X2DownloadableContentInfo_WOTC_MoreResistanceLeader'.static.DetermineSoldierTemplate();
+	if (ClassName == '')
+	{
+		NewTemplateName = 'Soldier';
+	}
+
 	//Use the character pool's creation method to retrieve a unit
-	NewUnitState = `CHARACTERPOOLMGR.CreateCharacter(NewGameState, `XPROFILESETTINGS.Data.m_eCharPoolUsage, nmCharacter, nmCountry);
+	NewUnitState = `CHARACTERPOOLMGR.CreateCharacter(NewGameState, `XPROFILESETTINGS.Data.m_eCharPoolUsage, NewTemplateName, nmCountry);
 	NewUnitState.RandomizeStats();	
 
 	if (NewUnitState.IsSoldier())


### PR DESCRIPTION
Should allow the user to define the template of the RescueClasses unit, instead of it defaulting to 'Soldier'